### PR TITLE
Proposed changes to right pane look&feel

### DIFF
--- a/assets/client/index.html
+++ b/assets/client/index.html
@@ -65,26 +65,26 @@ X88% : '%8888"    "888*""888"    ""   'Y"   "888*""888"  `"888*""     `Y"   'YP
 				</div>
 				<div id='tab-contents'>
 					<div id='roster' class='tab-content'>
-						<div id='roster-header'>
+						<div id='roster-header' class='col-xs-12'>
 							<div class='row'>
-								<div class='name'>
+								<div class='name col-xs-4'>
 									<h4>Name</h4>
 								</div>
-								<div class=''>
+								<div class='col-xs-2'>
 									<h4>State</h4>
 								</div>
-								<div class=''>
+								<div class='col-xs-2'>
 									<h4>Class</h4>
 								</div>
-								<div class=''>
+								<div class='col-xs-2'>
 									<h4>Allegiance</h4>
 								</div>
-								<div class=''>
+								<div class='col-xs-2'>
 									<h4># Mdfrs</h4>
 								</div>
 							</div>
 						</div>
-						<div id='roster-data'></div>
+						<div id='roster-data' class='col-xs-12'></div>
 					</div>
 					<div id='game-info' class='tab-content'>
 						<div id='details-wrapper'>

--- a/assets/client/index.html
+++ b/assets/client/index.html
@@ -178,17 +178,17 @@ X88% : '%8888"    "888*""888"    ""   'Y"   "888*""888"  `"888*""     `Y"   'YP
 						</div>
 						<div id='inventory-wrapper'>
 							<h3>Inventory</h3>
-							<div class='row' id='gold-row'>
-								<div class='col-xs-3'>
-									<h4>Gold: </h4>
-								</div>
-								<div class='col-xs-9'>
-									<h4 id='gold-amount'>gold here</h4>
+							<div id='gold-row'>
+								<div class='row'>
+									<div class='col-xs-9 item-name'>
+										<div>Gold</div>
+									</div>
+									<div class='col-xs-3 item-data'>
+										<div id='gold-amount'>gold here</div>
+									</div>
 								</div>
 							</div>
-							<div class='row'>
-								<div class='col-xs-12 container' id='items-wrapper'></div>
-							</div>
+							<div class='container' id='items-wrapper'></div>
 						</div>
 						<div id='map-wrapper'>
 							<h3>Map</h3>

--- a/assets/client/index.html
+++ b/assets/client/index.html
@@ -176,7 +176,6 @@ X88% : '%8888"    "888*""888"    ""   'Y"   "888*""888"  `"888*""     `Y"   'YP
 								</div>
 							</div>
 						</div>
-						<hr>
 						<div id='inventory-wrapper'>
 							<h3>Inventory</h3>
 							<div class='row' id='gold-row'>
@@ -191,7 +190,6 @@ X88% : '%8888"    "888*""888"    ""   'Y"   "888*""888"  `"888*""     `Y"   'YP
 								<div class='col-xs-12 container' id='items-wrapper'></div>
 							</div>
 						</div>
-						<hr>
 						<div id='map-wrapper'>
 							<h3>Map</h3>
 							<pre id='player-map'></pre>

--- a/assets/client/index.html
+++ b/assets/client/index.html
@@ -178,14 +178,12 @@ X88% : '%8888"    "888*""888"    ""   'Y"   "888*""888"  `"888*""     `Y"   'YP
 						</div>
 						<div id='inventory-wrapper'>
 							<h3>Inventory</h3>
-							<div id='gold-row'>
-								<div class='row'>
-									<div class='col-xs-9 item-name'>
-										<div>Gold</div>
-									</div>
-									<div class='col-xs-3 item-data'>
-										<div id='gold-amount'>gold here</div>
-									</div>
+							<div id='gold-row' class='row'>
+								<div class='col-xs-9 item-name'>
+									<div>Gold</div>
+								</div>
+								<div class='col-xs-3 item-data'>
+									<div id='gold-amount'>gold here</div>
 								</div>
 							</div>
 							<div class='container' id='items-wrapper'></div>

--- a/assets/client/styles/main.css
+++ b/assets/client/styles/main.css
@@ -234,46 +234,6 @@ body {
   max-height: 15vh;
 }
 
-/*
-FIXME: Fix the layout of the RHS pane.
-#tab-container #tab-navs {
-  border-color: var(--xanadu-near-black);
-  margin-bottom: 1em;
-}
-
-#tab-container #tab-navs li a {
-  background-color: var(--xanadu-black);
-  border-color: var(--xanadu-near-black);
-  color: var(--xanadu-red);
-}
-
-#tab-container #tab-navs li a:hover {
-  background-color: var(--xanadu-red);
-  color: var(--xanadu-near-black);
-}
-
-#tab-container #tab-navs li.active {
-  border-color: var(--xanadu-red);
-}
-
-#tab-container #tab-navs li.active a {
-  background-color: var(--xanadu-near-black);
-}
-
-#tab-container #tab-navs li.active a:hover {
-  color: var(--xanadu-red);
-}
-
-#tab-container div.tab-content {
-  max-height: 73vh;
-  overflow-y: scroll;
-  border-color: var(--xanadu-near-black);
-  border-style: solid;
-  border-width: 0 1px 1px 1px;
-  padding-bottom: 1em;
-}
-*/
-
 #tab-buttons {
   overflow: hidden;
   border: 1px solid var(--xanadu-grey);
@@ -340,6 +300,7 @@ FIXME: Fix the layout of the RHS pane.
   padding-bottom: 0.25em;
 }
 
+/* TODO: Try to get rid of px measurements in favor of vw, vh, and em. */
 #roster-header .row {
   padding: 0 10px;
 }
@@ -355,10 +316,6 @@ FIXME: Fix the layout of the RHS pane.
   border-left: 1px solid var(--xanadu-red);
   border-right: 1px solid var(--xanadu-red);
 }
-
-/*#roster #roster-data div.row.me div.roster-name::before {
-  content: '>';
-}*/
 
 #effect-data div.progress {
   background-color: var(--xanadu-black);
@@ -434,7 +391,6 @@ div.item-box {
  width: 100%;
  margin: 0;
  border-top: 1px solid var(--xanadu-grey);
- /* border-bottom: 1px solid grey; */
 }
 
 .item-box:last-child {
@@ -465,7 +421,7 @@ div.item-box:nth-child(odd) {
 
 div.item-condition, div.item-stack {
   padding-bottom: 1em;
-  /* XXX: any border? */
+  /* TODO: any border? */
 }
 
 div.item-condition.good-condition {

--- a/assets/client/styles/main.css
+++ b/assets/client/styles/main.css
@@ -374,6 +374,7 @@ FIXME: Fix the layout of the RHS pane.
   background-color: var(--xanadu-black);
   color: var(--xanadu-white);
   border: 1px solid var(--xanadu-near-black);
+  min-height: 150px;
 }
 
 #player-map span {
@@ -414,6 +415,15 @@ FIXME: Fix the layout of the RHS pane.
   height: 33%;
 }
 
+#inventory-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+#gold-row {
+  font-weight: bold;
+}
+
 #gold-amount {
   text-align: center;
   color: var(--xanadu-yellow);
@@ -422,13 +432,30 @@ FIXME: Fix the layout of the RHS pane.
 div.item-box {
  width: 100%;
  margin: 0;
- height: 5vh;
  border-top: 1px solid var(--xanadu-grey);
  /* border-bottom: 1px solid grey; */
 }
 
+.item-box:last-child {
+  border-bottom: 1px solid var(--xanadu-grey);
+}
+
 div.item-box:nth-child(odd) {
   background-color: var(--xanadu-near-black);
+}
+
+.item-name, .item-data {
+  padding-top: 1.33em;
+  padding-bottom: 1.33em;
+}
+
+.item-name {
+  margin-right: 50px;
+  text-align: right;
+}
+
+.item-data {
+  text-align: center;
 }
 
 #items-wrapper {
@@ -453,7 +480,7 @@ div.item-condition.poor-condition {
 }
 
 div.item-stack {
-  background-color: var(--xanadu-grey);
+  background-color: var(--xanadu-dark-grey);
 }
 
 #map-wrapper {

--- a/assets/client/styles/main.css
+++ b/assets/client/styles/main.css
@@ -29,6 +29,7 @@
   --xanadu-losat-blue:      #85C3C7;
 }
 
+/* TODO: Change the prefix since `col-xs` is no longer meaningful without Bootstrap. */
 .col-xs-1 {
   width: 8.333333%;
 }

--- a/assets/client/styles/main.css
+++ b/assets/client/styles/main.css
@@ -29,6 +29,54 @@
   --xanadu-losat-blue:      #85C3C7;
 }
 
+.col-xs-1 {
+  width: 8.333333%;
+}
+
+.col-xs-2 {
+  width: 16.666667%;
+}
+
+.col-xs-3 {
+  width: 25%;
+}
+
+.col-xs-4 {
+  width: 33.333333%;
+}
+
+.col-xs-5 {
+  width: 41.666667%;
+}
+
+.col-xs-6 {
+  width: 50%;
+}
+
+.col-xs-7 {
+  width: 58.333333%;
+}
+
+.col-xs-8 {
+  width: 66.666667%;
+}
+
+.col-xs-9 {
+  width: 75%;
+}
+
+.col-xs-10 {
+  width: 83.333333%;
+}
+
+.col-xs-11 {
+  width: 91.666667%;
+}
+
+.col-xs-12 {
+  width: 100%;
+}
+
 body {
   font-family: var(--xanadu-fonts);
   background-color: var(--xanadu-black);
@@ -283,10 +331,6 @@ FIXME: Fix the layout of the RHS pane.
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-}
-
-#roster-header .name, #roster-data .roster-name {
-  width: 25%;
 }
 
 #roster #roster-header {

--- a/assets/client/styles/main.css
+++ b/assets/client/styles/main.css
@@ -340,12 +340,12 @@ FIXME: Fix the layout of the RHS pane.
 }
 
 #roster-header .row {
-  padding: 0 5px;
+  padding: 0 10px;
 }
 
 #roster #roster-data div.row {
   margin-bottom: 1em;
-  padding: 0 5px;
+  padding: 0 10px;
   font-size: 1.25em;
   word-wrap: break-word;
 }

--- a/assets/client/styles/main.css
+++ b/assets/client/styles/main.css
@@ -295,8 +295,13 @@ FIXME: Fix the layout of the RHS pane.
   padding-bottom: 0.25em;
 }
 
+#roster-header .row {
+  padding: 0 5px;
+}
+
 #roster #roster-data div.row {
   margin-bottom: 1em;
+  padding: 0 5px;
   font-size: 1.25em;
   word-wrap: break-word;
 }

--- a/assets/client/styles/main.css
+++ b/assets/client/styles/main.css
@@ -264,6 +264,10 @@ FIXME: Fix the layout of the RHS pane.
   color: var(--xanadu-white);
 }
 
+#tab-contents {
+  overflow: auto;
+}
+
 #tab-contents .tab-content {
   display: none;
   padding: 0.3em 0.5em;

--- a/assets/client/styles/main.css
+++ b/assets/client/styles/main.css
@@ -228,6 +228,7 @@ FIXME: Fix the layout of the RHS pane.
 #tab-buttons {
   overflow: hidden;
   border: 1px solid var(--xanadu-grey);
+  border-right: none;
   background-color: var(--xanadu-near-black);
   display: flex;
   flex-direction: row;

--- a/src/client/clientSpec.ts
+++ b/src/client/clientSpec.ts
@@ -401,7 +401,7 @@ describe('Client', function() {
     describe('Gold', function() {
       it('should appear in the view', function() {
         return originalTestDetailsUpdatePromise.then($selectors => {
-          expect(getText($selectors, '#gold-row')).to.equal('Gold: 7890');
+          expect(getText($selectors, '#gold-row')).to.equal('Gold 7890');
           return $selectors;
         });
       });


### PR DESCRIPTION
This is more of a request for comment than anything else, because I don't know if you want to go in this direction.

I've (temporarily?) added simplified column width classes to restore some semblance of how the grids used to look, because (IMO) it's a lot easier to iterate by preserving an existing layout with a visual aid.

I reverted some changes to move grid widths into element-specific styles because I think those stragglers would be confusing given the above.

Summary of the changes:
- Set overflow to auto for the tab contents.
- Remove right border on tab buttons container.
- Fix the table layout of the player roster (with column classes, for now).
- Align the text in the inventory sections vertically and horizontally.
- Make item stack background color darker grey, to differ from the border.
- Add border at the bottom of the inventory.
- Give the map a slightly larger minimum height.
- Remove horizontal rules. They were ugly before and are nonfunctioning now.

Screenshots:

![roster](https://user-images.githubusercontent.com/884552/37074336-ed9d6d42-2191-11e8-845e-c8374766d5c2.png)
![game information](https://user-images.githubusercontent.com/884552/37074340-efc45d1a-2191-11e8-937d-dfd53a8aacf2.png)
